### PR TITLE
Adjust release naming

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,11 @@ package:
   version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/archive/v.{{ version }}.tar.gz
-  sha256: 9b4bdc0ad6eda38ea121d9fce1cd30c8b2e911e8c7a10b29cf24040b5af602b5
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: cf3b8f778346fef446818a0b518c8e3b2eed0dd953aa613cf256d4c56780eab4
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The vscode-icons team has changed the name of their release tags and also rereleased those tags.
https://github.com/vscode-icons/vscode-icons/tags